### PR TITLE
Fix slice, add Vec::into_traversal(), add quickcheck tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,5 @@ license = "MIT/Apache-2.0"
 [dependencies.num]
 
 [dev-dependencies]
-rand="*"
+quickcheck = "*"
+rand = "*"

--- a/benches/bench_slice.rs
+++ b/benches/bench_slice.rs
@@ -1,0 +1,30 @@
+#![feature(test)]
+
+extern crate test;
+extern crate traverse;
+extern crate rand;
+
+use traverse::Traversal;
+use test::Bencher;
+
+#[bench]
+fn bench_internal(bench: &mut Bencher) {
+    use rand::random;
+
+    let data: Vec<usize> = (0..10000).map(|_| random()).collect();
+    bench.iter(|| {
+        data.run(|x| { ::test::black_box(x); });
+    });
+}
+
+#[bench]
+fn bench_external(bench: &mut Bencher) {
+    use rand::random;
+
+    let data: Vec<usize> = (0..10000).map(|_| random()).collect();
+    bench.iter(|| {
+        for datum in data.iter() {
+            ::test::black_box(datum);
+        }
+    });
+}

--- a/src/impls/mod.rs
+++ b/src/impls/mod.rs
@@ -3,17 +3,7 @@ use std::hash::Hash;
 use super::*;
 
 mod slice;
-
-impl<T> FromTraversal<T> for Vec<T> {
-	fn from_traversal<I: IntoTraversal<Item=T>>(traversable: I) -> Self {
-		let trav = traversable.into_traversal();
-		let mut new = Self::with_capacity(trav.size_hint().0);
-		trav.run(|elem| {
-			new.push(elem);
-		});
-		new
-	}
-}
+mod vec;
 
 impl<T> FromTraversal<T> for VecDeque<T> {
 	fn from_traversal<I: IntoTraversal<Item=T>>(traversable: I) -> Self {

--- a/src/impls/mod.rs
+++ b/src/impls/mod.rs
@@ -58,4 +58,3 @@ impl<K: Ord, V> FromTraversal<(K, V)> for BTreeMap<K, V> {
 		new
 	}
 }
-

--- a/src/impls/mod.rs
+++ b/src/impls/mod.rs
@@ -2,6 +2,8 @@ use std::collections::*;
 use std::hash::Hash;
 use super::*;
 
+mod slice;
+
 impl<T> FromTraversal<T> for Vec<T> {
 	fn from_traversal<I: IntoTraversal<Item=T>>(traversable: I) -> Self {
 		let trav = traversable.into_traversal();

--- a/src/impls/slice.rs
+++ b/src/impls/slice.rs
@@ -1,5 +1,5 @@
-use std::{mem, raw};
-use {Traversal};
+use std::mem;
+use Traversal;
 
 impl<'a, T> Traversal for &'a [T] {
     type Item = &'a T;
@@ -7,18 +7,19 @@ impl<'a, T> Traversal for &'a [T] {
     #[inline]
     fn foreach<F>(self, mut f: F) where F: FnMut(&'a T) -> bool {
         unsafe {
-            let slice = mem::transmute::<&'a [T], raw::Slice<T>>(self);
+            let ptr = self.as_ptr();
+            let len = self.len();
 
             let is_zero_size = mem::size_of::<T>() == 0;
 
             if is_zero_size {
-                for _ in 0..slice.len() {
+                for _ in 0..len {
                     // Just give some pointer, doesn't matter what.
                     if f(mem::transmute(1usize)) { break }
                 }
             } else {
-                let mut current = slice.data;
-                let end = slice.data.offset(slice.len as isize);
+                let mut current = ptr;
+                let end = ptr.offset(len as isize);
                 while current != end {
                     if f(mem::transmute(current)) { break }
                     current = current.offset(1);
@@ -34,18 +35,19 @@ impl<'a, T> Traversal for &'a mut [T] {
     #[inline]
     fn foreach<F>(self, mut f: F) where F: FnMut(&'a mut T) -> bool {
         unsafe {
-            let slice = mem::transmute::<&'a mut [T], raw::Slice<T>>(self);
+            let ptr = self.as_mut_ptr();
+            let len = self.len();
 
             let is_zero_size = mem::size_of::<T>() == 0;
 
             if is_zero_size {
-                for _ in 0..slice.len {
+                for _ in 0..len {
                     // Just give some pointer, doesn't matter what.
                     if f(mem::transmute(1usize)) { break }
                 }
             } else {
-                let mut current = slice.data;
-                let end = slice.data.offset(slice.len as isize);
+                let mut current = ptr;
+                let end = ptr.offset(len as isize);
                 while current != end {
                     if f(mem::transmute(current)) { break }
                     current = current.offset(1);

--- a/src/impls/vec.rs
+++ b/src/impls/vec.rs
@@ -1,10 +1,41 @@
-use {Traversal, FromTraversal};
+use std::vec;
+use {Traversal, IntoTraversal, FromTraversal, Internal};
 
-impl<T> FromTraversal<T> for Vec<T> {
-    fn collect<I: Traversal<Item=T>>(iter: I) -> Vec<T> {
-        let mut vec = Vec::new();
-        iter.run(|elem| vec.push(elem));
-        vec
+impl<T> IntoTraversal for Vec<T> {
+    type IntoTrav = Internal<vec::IntoIter<T>>;
+    type Item = T;
+
+    fn into_traversal(self) -> Self::IntoTrav {
+        Internal::new(self.into_iter())
     }
 }
 
+impl<T> FromTraversal<T> for Vec<T> {
+	fn from_traversal<I: IntoTraversal<Item=T>>(traversable: I) -> Self {
+		let trav = traversable.into_traversal();
+		let mut new = Self::with_capacity(trav.size_hint().0);
+		trav.run(|elem| {
+			new.push(elem);
+		});
+		new
+	}
+}
+
+#[cfg(test)]
+mod test {
+    use {Traversal, IntoTraversal};
+
+    #[test]
+    fn test_basic() {
+        let data = vec![1, 2, 5, 4, 6, 7];
+        let traversal: Vec<usize> = data.clone().into_traversal().collect();
+        assert_eq!(traversal, data);
+    }
+
+    #[test]
+    fn test_zero_size() {
+        let data = vec![(), (), ()];
+        let traversal: Vec<()> = data.clone().into_traversal().collect();
+        assert_eq!(traversal, data);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,10 @@
 // For CheckedAdd
 extern crate num;
 
+mod ext;
+pub mod utils;
+mod impls;
+
 /// An iterator that runs all at once
 pub trait Traversal: Sized {
     type Item;
@@ -204,7 +208,3 @@ pub struct FlatMap<I, F> {
 pub struct Cloned<I> {
     iter: I,
 }
-
-mod ext;
-pub mod utils;
-mod impls;

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,0 +1,30 @@
+extern crate quickcheck;
+extern crate traverse;
+
+use traverse::Traversal;
+
+#[test]
+fn quickcheck_map() {
+    fn add_one(x: &u32) -> u32 { *x + 1 }
+
+    fn prop(vec: Vec<u32>) -> bool {
+        let expected: Vec<_> = vec.iter().map(add_one).collect();
+        let result: Vec<_> = vec.map(add_one).collect();
+        expected == result
+    }
+
+    quickcheck::quickcheck(prop as fn(Vec<u32>) -> bool);
+}
+
+#[test]
+fn quickcheck_filter() {
+    fn is_even(x: & &u32) -> bool { **x % 2 == 0 }
+
+    fn prop(vec: Vec<u32>) -> bool {
+        let expected: Vec<&u32> = vec.iter().filter(is_even).collect();
+        let result: Vec<&u32> = vec.filter(is_even).collect();
+        expected == result
+    }
+
+    quickcheck::quickcheck(prop as fn(Vec<u32>) -> bool);
+}


### PR DESCRIPTION
Before this patch, it wasn't possible to convert slices automatically into traversals since the module wasn't being included. Assuming that this was accidental, this fixes it. It also implements `IntoTraversal` for `Vec<T>`, factors out the benchmarks, and adds some quickchecks to make sure our behavior is compatible with iterators.