### PR TITLE
provide dependency (num) version in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "traverse"
-version = "0.0.12"
+version = "0.0.13"
 authors = ["Jonathan Reem <jonathan.reem@gmail.com>",
            "Alexis Beingessner <a.beingessner@gmail.com>"]
 repository = "https://github.com/reem/rust-traverse.git"
@@ -10,6 +10,7 @@ readme = "README.md"
 license = "MIT/Apache-2.0"
 
 [dependencies.num]
+version = "*"
 
 [dev-dependencies]
 quickcheck = "*"


### PR DESCRIPTION
In rustc 1.78.0 (9b00956e5 2024-04-29) and earlier versions, a warning is emitted during cargo build:
```
warning: dependency (num) specified without providing a local path, Git repository, version, or workspace dependency to use. This will be considered an error in future versions
```

That day has finally arrived.

Starting with rustc 1.79.0 (129f3b996 2024-06-10), this crate can no longer be built:
```
error: failed to parse manifest at `${workdir}/rust-traverse/Cargo.toml`

Caused by:
  dependency (num) specified without providing a local path, Git repository, version, or workspace dependency to use
```

I provide a version for dependency `num` . I hope this can help 💖. 